### PR TITLE
Add list command to enumerate drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Commands:
   new                    create new draft
   prepend                prepend to draft
   append                 append to draft
-  replace                append to draft
+  replace                replace content of draft
   edit                   edit draft in $EDITOR
   get                    get content of draft
   select                 select active draft using fzf
+  list                   list drafts
 ```
 
 See further: `drafts <command> --help`

--- a/pkg/drafts/js/query.js
+++ b/pkg/drafts/js/query.js
@@ -1,4 +1,6 @@
-let ds = Draft.query(...input);
+let [queryString, filter, tags, omitTags, sort, sortDescending, sortFlaggedToTop] = input;
+let ds = Draft.query(queryString, filter, tags || [], omitTags || [], sort, sortDescending, sortFlaggedToTop);
+if (!ds) ds = [];
 let res = ds.map((d) => ({
   uuid: d.uuid,
   content: d.content,


### PR DESCRIPTION
## Summary

- Adds a `list` subcommand to enumerate drafts with filter and tag options
- Fixes `query.js` to handle nil tags/omitTags arrays (was causing "undefined is not an object" error)
- Fixes typo in replace command help text ("append to draft" → "replace content of draft")

## Usage

```bash
drafts list                 # list inbox drafts (default)
drafts list -f all          # list all drafts
drafts list -f archive      # list archived drafts
drafts list -f flagged      # list flagged drafts
drafts list -f trash        # list trashed drafts
drafts list -t mytag        # filter by tag
```

Output format: `UUID<tab>first line of content` (truncated to 80 chars)

## Test plan

- [x] Tested `drafts list` with default inbox filter
- [x] Tested `drafts list -f all` 
- [x] Verified output format shows UUID and first line

🤖 Generated with [Claude Code](https://claude.com/claude-code)